### PR TITLE
Only run build and distribute when releasing.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,10 +5,13 @@ on:
     paths-ignore:
       - 'README.md'
       - 'static/**'
+  release:
+    types: [published]
 jobs:
   build-n-publish:
     name: Build
     runs-on: ubuntu-18.04
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Not necessary/desirable to try building&distributing to PyPi on every push.

The specific implementation of the change is based on what I saw in github workflows from a few other Farama Foundation repos.

Please let me know if I should copy other parts from other repos right away, now that we're here anyway.