### PR TITLE
Allows passing custom JVM args to JVM from python.

### DIFF
--- a/gym_microrts/envs/vec_env.py
+++ b/gym_microrts/envs/vec_env.py
@@ -53,6 +53,7 @@ class MicroRTSGridModeVecEnv:
         reward_weight=np.array([0.0, 1.0, 0.0, 0.0, 0.0, 5.0]),
         cycle_maps=[],
         autobuild=True,
+        jvm_args=[],
     ):
 
         self.num_selfplay_envs = num_selfplay_envs
@@ -113,7 +114,7 @@ class MicroRTSGridModeVecEnv:
             ]
             for jar in jars:
                 jpype.addClassPath(os.path.join(self.microrts_path, jar))
-            jpype.startJVM(convertStrings=False)
+            jpype.startJVM(*jvm_args, convertStrings=False)
 
         # start microrts client
         from rts.units import UnitTypeTable
@@ -297,6 +298,7 @@ class MicroRTSBotVecEnv(MicroRTSGridModeVecEnv):
         map_paths="maps/10x10/basesTwoWorkers10x10.xml",
         reward_weight=np.array([0.0, 1.0, 0.0, 0.0, 0.0, 5.0]),
         autobuild=True,
+        jvm_args=[],
     ):
 
         self.ai1s = ai1s
@@ -345,7 +347,7 @@ class MicroRTSBotVecEnv(MicroRTSGridModeVecEnv):
             ]
             for jar in jars:
                 jpype.addClassPath(os.path.join(self.microrts_path, jar))
-            jpype.startJVM(convertStrings=False)
+            jpype.startJVM(*jvm_args, convertStrings=False)
 
         # start microrts client
         from rts.units import UnitTypeTable


### PR DESCRIPTION
Default behaviour remains unchanged.

Any strings that are passed into the new `jvm_args` list will be used as JVM args when launching the JVM. This may be useful for some users for things such as:
- Adding an agent for profiling
- Explicitly setting min/max heap size for JVM
- Specifying a path for a heap dump to get written to on out-of-memory-errors (always a good idea when running many Java-based experiments on a cluster for example, such that in hindsight you can inspect the heap dumps if it turned out there were any out of memory crashes)
- etc....

**Question:** For now, I did not (yet?) change any of the locations where `MicroRTSGridModeVecEnv` or `MicroRTSBotVecEnv` objects are created, so there's not actually a direct way for users to pass JVM args now. Maybe I should. This would be places such as the `"__main__"` code block of `ppo_gridnet.py` (for example), where I could then accept JVM args passed by the user via `argparse`. Not sure if I should go through every single place where these envs are currently being created and do it already, or only do it on a case-by-case basis as I find myself using it...