### PR TITLE
Reducing used memory and and removing some unused code in ppo_gridnet_eval

### DIFF
--- a/experiments/ppo_gridnet_eval.py
+++ b/experiments/ppo_gridnet_eval.py
@@ -8,7 +8,6 @@ from distutils.util import strtobool
 
 import numpy as np
 import torch
-import torch.optim as optim
 from gym.spaces import MultiDiscrete
 from stable_baselines3.common.vec_env import VecMonitor, VecVideoRecorder
 from torch.utils.tensorboard import SummaryWriter
@@ -133,14 +132,12 @@ if __name__ == "__main__":
 
     agent = Agent(envs).to(device)
     agent2 = Agent(envs).to(device)
-    optimizer = optim.Adam(agent.parameters(), lr=args.learning_rate, eps=1e-5)
 
     # ALGO Logic: Storage for epoch data
     mapsize = 16 * 16
-    action_space_shape = (mapsize, len(envs.action_plane_space.nvec))
     invalid_action_shape = (mapsize, envs.action_plane_space.nvec.sum())
 
-    invalid_action_masks = torch.zeros((args.num_steps, args.num_envs) + invalid_action_shape).to(device)
+    invalid_action_masks = torch.zeros((1, args.num_envs) + invalid_action_shape).to(device)
     # TRY NOT TO MODIFY: start the game
     global_step = 0
     start_time = time.time()
@@ -170,17 +167,17 @@ if __name__ == "__main__":
             global_step += 1 * args.num_envs
             # ALGO LOGIC: put action logic here
             with torch.no_grad():
-                invalid_action_masks[step] = torch.tensor(np.array(envs.get_action_mask())).to(device)
+                invalid_action_masks[0] = torch.tensor(np.array(envs.get_action_mask())).to(device)
 
                 if args.ai:
                     action, logproba, _, _, vs = agent.get_action_and_value(
-                        next_obs, envs=envs, invalid_action_masks=invalid_action_masks[step], device=device
+                        next_obs, envs=envs, invalid_action_masks=invalid_action_masks[0], device=device
                     )
                 else:
                     p1_obs = next_obs[::2]
                     p2_obs = next_obs[1::2]
-                    p1_mask = invalid_action_masks[step][::2]
-                    p2_mask = invalid_action_masks[step][1::2]
+                    p1_mask = invalid_action_masks[0][::2]
+                    p2_mask = invalid_action_masks[0][1::2]
 
                     p1_action, _, _, _, _ = agent.get_action_and_value(
                         p1_obs, envs=envs, invalid_action_masks=p1_mask, device=device

--- a/experiments/ppo_gridnet_eval.py
+++ b/experiments/ppo_gridnet_eval.py
@@ -137,7 +137,6 @@ if __name__ == "__main__":
     mapsize = 16 * 16
     invalid_action_shape = (mapsize, envs.action_plane_space.nvec.sum())
 
-    invalid_action_masks = torch.zeros((1, args.num_envs) + invalid_action_shape).to(device)
     # TRY NOT TO MODIFY: start the game
     global_step = 0
     start_time = time.time()
@@ -167,17 +166,17 @@ if __name__ == "__main__":
             global_step += 1 * args.num_envs
             # ALGO LOGIC: put action logic here
             with torch.no_grad():
-                invalid_action_masks[0] = torch.tensor(np.array(envs.get_action_mask())).to(device)
+                invalid_action_masks = torch.tensor(np.array(envs.get_action_mask())).to(device)
 
                 if args.ai:
                     action, logproba, _, _, vs = agent.get_action_and_value(
-                        next_obs, envs=envs, invalid_action_masks=invalid_action_masks[0], device=device
+                        next_obs, envs=envs, invalid_action_masks=invalid_action_masks, device=device
                     )
                 else:
                     p1_obs = next_obs[::2]
                     p2_obs = next_obs[1::2]
-                    p1_mask = invalid_action_masks[0][::2]
-                    p2_mask = invalid_action_masks[0][1::2]
+                    p1_mask = invalid_action_masks[::2]
+                    p2_mask = invalid_action_masks[1::2]
 
                     p1_action, _, _, _, _ = agent.get_action_and_value(
                         p1_obs, envs=envs, invalid_action_masks=p1_mask, device=device


### PR DESCRIPTION
The main purpose of this PR is to reduce (seemingly unnecessary) memory usage of `invalid_action_masks` in `ppo_gridnet_eval.py`.

It used to be initialised as:

```python
invalid_action_masks = torch.zeros((args.num_steps, args.num_envs) + invalid_action_shape).to(device)
```

where `invalid_action_shape` is quite a huge number, hence making the entire tensor quite huge (with `args.num_steps` defaulting to 256, and `args.num_envs` usually being low, like 1 or 2). 

However, the use of `args.num_steps` here seems to be an artefact of copy/pasting from training code. In this eval-only code, it's only ever indexed by `step` (the current step/frame in our loop through the environment), and after progressing to the next step, we never index with lower steps again. So really, we only need `1` here instead of `args.num_steps`, and we can re-use the same block of memory throughout different steps.

I've also removed a couple of other variables that are not relevant during eval (like the optimizer).