### PR TITLE
Disable faulthandler for pytest.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,4 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: |
-            xvfb-run -a poetry run pytest tests -v -p no:faulthandle
+            xvfb-run -a poetry run pytest -p no:faulthandle tests -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,4 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: |
-            xvfb-run -a poetry run pytest tests -v
+            xvfb-run -a poetry run pytest tests -v -p no:faulthandle


### PR DESCRIPTION
This project uses `jpype` to run Java code from Python.

There is an annoying issue where, when `pytest` is combined with `jpype`, the latter sometimes crashes with a Segmentation Fault all the way at the end when automatically trying to shut down the Java Virtual Machine (after all tests have already been run and passed). This sometimes causes our github workflows to report failure, and the solution is always just to... re-run it again and hope it doesn't crash the second time.

I found an [Issue about this over on the github repo of jpype itself](https://github.com/jpype-project/jpype/issues/842), and the solution proposed all the way at the end there is to pass `-p no:faulthandler` to `pytest`. It looks like this is also the solution that was implemented in the CI of jpype itself. So, that's what I also try here.

It was a non-deterministic issue so I can't be 100% sure, but I made the build re-run many times for this PRs and didn't see it again, so I hope it's fixed. I did once have it fail with 

`ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running`

through a Stable Baselines import though, not sure yet what to do about that.