### PR TITLE
Retiring shared mem vec env (temporarily? permanently? I dont know)

### DIFF
--- a/experiments/ppo_gridnet_eval.py
+++ b/experiments/ppo_gridnet_eval.py
@@ -78,9 +78,7 @@ if __name__ == "__main__":
     else:
         from ppo_gridnet import Agent, MicroRTSStatsRecorder
 
-        from gym_microrts.envs.vec_env import (
-            MicroRTSGridModeSharedMemVecEnv as MicroRTSGridModeVecEnv,
-        )
+        from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv
 
     # TRY NOT TO MODIFY: setup the environment
     experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"


### PR DESCRIPTION
For consistency with https://github.com/Farama-Foundation/MicroRTS-Py/pull/104#discussion_r1211906907. Shared mem vec env is currently unsupported (as far as I know). 